### PR TITLE
[Perf] Distribute prebuilt artifact bundles via mise spm backend

### DIFF
--- a/.github/workflows/ArtifactBundle.yaml
+++ b/.github/workflows/ArtifactBundle.yaml
@@ -1,0 +1,108 @@
+name: ArtifactBundle
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to build the artifact bundle for (defaults to the latest release)
+        required: false
+        default: ""
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+
+  resolve-tag:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+    - id: tag
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        INPUT_TAG: ${{ inputs.tag }}
+      run: |
+        tag="${INPUT_TAG:-$(gh release view --repo ${{ github.repository }} --json tagName --jq .tagName)}"
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+  build-binaries:
+    needs: resolve-tag
+    strategy:
+      matrix:
+        include:
+        - os: ubuntu-24.04
+          triple: x86_64-unknown-linux-gnu
+        - os: ubuntu-24.04-arm
+          triple: aarch64-unknown-linux-gnu
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ needs.resolve-tag.outputs.tag }}
+    - name: Build static binaries
+      run: |
+        swift build -c release --static-swift-stdlib --product Release
+        swift build -c release --static-swift-stdlib --product Comment
+        # .build/release is a symlink; copy from the real bin path so
+        # upload-artifact picks up regular files.
+        bin="$(swift build -c release --show-bin-path)"
+        mkdir -p dist
+        cp "$bin/Release" "$bin/Comment" dist/
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.triple }}
+        path: dist
+        if-no-files-found: error
+
+  upload-artifact-bundle:
+    needs: [resolve-tag, build-binaries]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ needs.resolve-tag.outputs.tag }}
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        path: bins
+    - name: Assemble artifact bundle
+      run: |
+        bundle=GitHubSwiftActions.artifactbundle
+        for triple in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
+          mkdir -p "$bundle/$triple"
+          cp "bins/$triple/Release" "bins/$triple/Comment" "$bundle/$triple/"
+        done
+        cat > "$bundle/info.json" << EOF
+        {
+          "schemaVersion": "1.0",
+          "artifacts": {
+            "Release": {
+              "type": "executable",
+              "version": "$TAG",
+              "variants": [
+                { "path": "x86_64-unknown-linux-gnu/Release", "supportedTriples": ["x86_64-unknown-linux-gnu"] },
+                { "path": "aarch64-unknown-linux-gnu/Release", "supportedTriples": ["aarch64-unknown-linux-gnu"] }
+              ]
+            },
+            "Comment": {
+              "type": "executable",
+              "version": "$TAG",
+              "variants": [
+                { "path": "x86_64-unknown-linux-gnu/Comment", "supportedTriples": ["x86_64-unknown-linux-gnu"] },
+                { "path": "aarch64-unknown-linux-gnu/Comment", "supportedTriples": ["aarch64-unknown-linux-gnu"] }
+              ]
+            }
+          }
+        }
+        EOF
+        zip -r "$bundle.zip" "$bundle"
+    - name: Upload to release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release upload "$TAG" GitHubSwiftActions.artifactbundle.zip --repo ${{ github.repository }} --clobber

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -14,8 +14,16 @@ jobs:
     permissions:
       contents: write
     steps:
+    # The mise spm backend resolves refs/tags/<ref> only, so action_ref must be
+    # a release tag (with an artifact bundle attached) rather than "main".
+    - name: Resolve latest release tag
+      id: latest
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: echo "tag=$(gh release view --repo ${{ github.repository }} --json tagName --jq .tagName)" >> "$GITHUB_OUTPUT"
     - uses: Wei18/GitHubSwiftActions/Actions/Release@main
       with:
+        action_ref: ${{ steps.latest.outputs.tag }}
         owner: ${{ github.repository_owner }}
         repo: ${{ github.event.repository.name }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Welcome.yml
+++ b/.github/workflows/Welcome.yml
@@ -11,8 +11,16 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+    # The mise spm backend resolves refs/tags/<ref> only, so action_ref must be
+    # a release tag (with an artifact bundle attached) rather than "main".
+    - name: Resolve latest release tag
+      id: latest
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: echo "tag=$(gh release view --repo ${{ github.repository }} --json tagName --jq .tagName)" >> "$GITHUB_OUTPUT"
     - uses: Wei18/GitHubSwiftActions/Actions/Comment@main
       with:
+        action_ref: ${{ steps.latest.outputs.tag }}
         number: ${{ github.event.issue.number }}
         body: |
           Hello @${{ github.event.issue.user.login }},

--- a/Actions/Comment/action.yml
+++ b/Actions/Comment/action.yml
@@ -23,32 +23,19 @@ inputs:
 name: Comment
 runs:
   steps:
-  - name: Setup Swift
+  - name: Setup Mise
     uses: jdx/mise-action@v2
-    with:
-      mise_toml: |-
-        [tools]
-        swift = "5"
-        [settings]
-        experimental = true
-  - name: Create Mintfile
-    run: echo Wei18/GitHubSwiftActions@${{ inputs.action_ref }} > ${{ github.action_path }}/Mintfile
-    shell: bash
-  - name: Setup Mint
-    uses: irgaly/setup-mint@v1
-    with:
-      cache-prefix: ${{ github.action }}
-      mint-directory: ${{ github.action_path }}
-      mint-executable-directory: ~/.mint/bin
   - env:
       ACTION_REF: ${{ inputs.action_ref }}
       ANCHOR: ${{ inputs.anchor }}
       BODY: ${{ inputs.body }}
+      GITHUB_TOKEN: ${{ inputs.token }}
+      MISE_EXPERIMENTAL: '1'
       NUMBER: ${{ inputs.number }}
       OWNER: ${{ inputs.owner }}
       REPO: ${{ inputs.repo }}
       TOKEN: ${{ inputs.token }}
     name: Run Comment
-    run: ~/.mint/bin/mint run Wei18/GitHubSwiftActions@${{ inputs.action_ref }} Comment
+    run: mise x "spm:Wei18/GitHubSwiftActions@${{ inputs.action_ref }}" -- Comment
     shell: bash
   using: composite

--- a/Actions/Release/action.yml
+++ b/Actions/Release/action.yml
@@ -20,31 +20,18 @@ inputs:
 name: Release
 runs:
   steps:
-  - name: Setup Swift
+  - name: Setup Mise
     uses: jdx/mise-action@v2
-    with:
-      mise_toml: |-
-        [tools]
-        swift = "5"
-        [settings]
-        experimental = true
-  - name: Create Mintfile
-    run: echo Wei18/GitHubSwiftActions@${{ inputs.action_ref }} > ${{ github.action_path }}/Mintfile
-    shell: bash
-  - name: Setup Mint
-    uses: irgaly/setup-mint@v1
-    with:
-      cache-prefix: ${{ github.action }}
-      mint-directory: ${{ github.action_path }}
-      mint-executable-directory: ~/.mint/bin
   - env:
       ACTION_REF: ${{ inputs.action_ref }}
+      GITHUB_TOKEN: ${{ inputs.token }}
+      MISE_EXPERIMENTAL: '1'
       OWNER: ${{ inputs.owner }}
       REF: ${{ inputs.ref }}
       REPO: ${{ inputs.repo }}
       TOKEN: ${{ inputs.token }}
       TYPE: ${{ inputs.type }}
     name: Run Release
-    run: ~/.mint/bin/mint run Wei18/GitHubSwiftActions@${{ inputs.action_ref }} Release
+    run: mise x "spm:Wei18/GitHubSwiftActions@${{ inputs.action_ref }}" -- Release
     shell: bash
   using: composite

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "0741355188c93907f0d965ea72eb7880d09ec66f6340f6432fa77d909e7410c3",
+  "originHash" : "dd3d7b3bb7361839c914aa66bac4f624fd0f37f9baab9364c903b4858bf4a9b2",
   "pins" : [
     {
       "identity" : "github-rest-api-swift-openapi",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Wei18/github-rest-api-swift-openapi",
       "state" : {
-        "revision" : "15f8f4fac6879df4ee093710ebc35983deece11a",
-        "version" : "3.0.0"
+        "revision" : "272374cfb893fd5df74fef8265a405f0dda447f6",
+        "version" : "3.0.12"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
-        "version" : "1.1.3"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-urlsession",
       "state" : {
-        "revision" : "9bf4c712ad7989d6a91dbe68748b8829a50837e4",
-        "version" : "1.0.2"
+        "revision" : "279aa6b77be6aa842a4bf3c45fa79fa15edf3e07",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .executable(name: "Release", targets: ["Release"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Wei18/github-rest-api-swift-openapi", from: "3.0.0"),
+        .package(url: "https://github.com/Wei18/github-rest-api-swift-openapi", from: "3.0.12"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.0.0"),
         .package(url: "https://github.com/jpsim/Yams", from: "6.0.0"),

--- a/Sources/YamlWriter/CLIYamlBuilder.swift
+++ b/Sources/YamlWriter/CLIYamlBuilder.swift
@@ -35,9 +35,14 @@ struct CLIYamlBuilder {
         let factory = SetUpActionFactory()
         inputs.merge(factory.buildInputs()) { _, new in new }
 
-        let envDict = inputs.keys.reduce(into: [:]) { partialResult, value in
+        var envDict = inputs.keys.reduce(into: [String: String]()) { partialResult, value in
             partialResult[value.uppercased()] = "${{ inputs.\(value) }}"
         }
+        // mise queries the GitHub releases API to resolve the artifact bundle;
+        // unauthenticated requests hit rate limits on shared runner IPs.
+        envDict["GITHUB_TOKEN"] = "${{ inputs.token }}"
+        // The mise spm backend is gated behind the experimental flag.
+        envDict["MISE_EXPERIMENTAL"] = "1"
 
         let name = String(describing: command)
         let repo = SwiftPackageConfig.current.repo
@@ -53,7 +58,7 @@ struct CLIYamlBuilder {
                 [
                     [
                         "name": "Run \(name)",
-                        "run": "~/.mint/bin/mint run \(repo)@${{ inputs.action_ref }} \(name)",
+                        "run": "mise x \"spm:\(repo)@${{ inputs.action_ref }}\" -- \(name)",
                         "env": envDict,
                         "shell": "bash",
                     ],
@@ -78,35 +83,13 @@ private struct SetUpActionFactory {
     }
 
     func buildSteps() -> [[String: Any]] {
-        let content = "\(SwiftPackageConfig.current.repo)@${{ inputs.action_ref }}"
-        let miseToml = #"""
-            [tools]
-            swift = "5"
-            [settings]
-            experimental = true
-            """#
-
+        // The spm backend only needs `swift -print-target-info` to match the
+        // artifact bundle triple; GitHub-hosted runners ship with Swift, so no
+        // toolchain install step is required.
         let action: [[String: Any]] = [
             [
-                "name": "Setup Swift",
+                "name": "Setup Mise",
                 "uses": "jdx/mise-action@v2",
-                "with": [
-                    "mise_toml": Yams.Node.scalar(.init(miseToml, .implicit, .literal)),
-                ],
-            ],
-            [
-                "name": "Create Mintfile",
-                "run": "echo \(content) > ${{ github.action_path }}/Mintfile",
-                "shell": "bash",
-            ],
-            [
-                "name": "Setup Mint",
-                "uses": "irgaly/setup-mint@v1",
-                "with": [
-                    "mint-directory": "${{ github.action_path }}",
-                    "mint-executable-directory": "~/.mint/bin",
-                    "cache-prefix": "${{ github.action }}",
-                ],
             ],
         ]
         return action


### PR DESCRIPTION
## Why

`Actions/Release@1.0.9` (and Comment) took **~26 minutes** per consumer run (measured: run 15699482589). Root causes:

1. mint compiled the package from source on every cache miss — release-mode compilation of the generated OpenAPI modules (`repos` Types.swift 3.67MB + Client.swift 0.98MB) dominates on 2-core runners
2. A Swift toolchain was installed on every run
3. `Package.resolved` was stale-pinned to github-rest-api-swift-openapi **3.0.0** — the only tag still carrying the multi-GB `github/rest-api-description` submodule gitlink, which SwiftPM downloads on checkout (3.0.1+ removed it)

## What

- **Actions now run prebuilt binaries** via the [mise spm backend](https://mise.jdx.dev/dev-tools/backends/spm.html): `mise x "spm:Wei18/GitHubSwiftActions@<action_ref>" -- <Tool>` downloads the `*.artifactbundle.zip` attached to the matching release and runs it — no toolchain install, no compile. Expected run time: **~30s**.
- **New `ArtifactBundle` workflow**: after each Release succeeds, builds `--static-swift-stdlib` Linux binaries (x86_64 + aarch64), assembles `GitHubSwiftActions.artifactbundle.zip` (Release + Comment, per-triple variants in info.json) and uploads it to the release. Manual dispatch can backfill any existing tag.
- **Dogfooding workflows** resolve the latest release tag and pass it as `action_ref`, because the mise spm backend resolves `refs/tags/` only (verified empirically — branch refs fail). `uses: @main` still exercises the latest action steps.
- `action.yml` files regenerated by YamlWriter (template updated in `CLIYamlBuilder.swift`).
- Dependency bumped to 3.0.12 (`from: "3.0.12"`) so no source build ever downloads the submodule again. All API symbols used were verified present in 3.0.12.

## Verified facts (from mise source / runner-images docs)

- spm backend prefers `*.artifactbundle.zip` release assets matching the host triple; falls back to source build when absent (e.g. macOS runners) — degraded, not broken
- `swift -print-target-info` is required even on the bundle path → satisfied by preinstalled Swift on GitHub-hosted runners (ubuntu-24.04 ships Swift 6.3.1)
- spm backend requires `MISE_EXPERIMENTAL=1`; tag matching is exact with no v-prefix stripping (our bare-version tags are compatible)

## Bootstrap after merge

1. Dispatch **ArtifactBundle** with `tag=1.0.9` to backfill a bundle onto the existing release (one last CI compile)
2. Dispatch **Release** → creates the next tag → ArtifactBundle auto-runs via `workflow_run` → fully automatic thereafter

## Known tradeoffs

- mise spm backend is marked experimental
- Consumers pinning this action by branch/SHA fall back to the slow source-build path (tags get the fast path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)