### PR TITLE
[Fix] Build artifact bundles with the Static Linux SDK (musl)

### DIFF
--- a/.github/workflows/ArtifactBundle.yaml
+++ b/.github/workflows/ArtifactBundle.yaml
@@ -36,22 +36,32 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-24.04
-          triple: x86_64-unknown-linux-gnu
-        - os: ubuntu-24.04-arm
-          triple: aarch64-unknown-linux-gnu
-    runs-on: ${{ matrix.os }}
+        - triple: x86_64-unknown-linux-gnu
+          swift-sdk: x86_64-swift-linux-musl
+        - triple: aarch64-unknown-linux-gnu
+          swift-sdk: aarch64-swift-linux-musl
+    # Both targets cross-compile from x86_64 via the Static Linux SDK (musl),
+    # which produces fully static binaries with no runtime dependency on the
+    # host's Swift or libcurl (--static-swift-stdlib fails to link against
+    # Ubuntu's libcurl, which is built without websocket support).
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
         ref: ${{ needs.resolve-tag.outputs.tag }}
+    # The toolchain version must exactly match the Static Linux SDK version.
+    - uses: jdx/mise-action@v2
+      with:
+        mise_toml: |
+          [tools]
+          swift = "6.3.2"
+    - name: Install Static Linux SDK
+      run: swift sdk install https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz --checksum 3fd798bef6f4408f1ea5a6f94ce4d4052830c4326ab85ebc04f983f01b3da407
     - name: Build static binaries
       run: |
-        swift build -c release --static-swift-stdlib --product Release
-        swift build -c release --static-swift-stdlib --product Comment
-        # .build/release is a symlink; copy from the real bin path so
-        # upload-artifact picks up regular files.
-        bin="$(swift build -c release --show-bin-path)"
+        swift build -c release --swift-sdk ${{ matrix.swift-sdk }} --product Release
+        swift build -c release --swift-sdk ${{ matrix.swift-sdk }} --product Comment
+        bin="$(swift build -c release --swift-sdk ${{ matrix.swift-sdk }} --show-bin-path)"
         mkdir -p dist
         cp "$bin/Release" "$bin/Comment" dist/
     - uses: actions/upload-artifact@v4
@@ -86,16 +96,16 @@ jobs:
               "type": "executable",
               "version": "$TAG",
               "variants": [
-                { "path": "x86_64-unknown-linux-gnu/Release", "supportedTriples": ["x86_64-unknown-linux-gnu"] },
-                { "path": "aarch64-unknown-linux-gnu/Release", "supportedTriples": ["aarch64-unknown-linux-gnu"] }
+                { "path": "x86_64-unknown-linux-gnu/Release", "supportedTriples": ["x86_64-unknown-linux-gnu", "x86_64-swift-linux-musl"] },
+                { "path": "aarch64-unknown-linux-gnu/Release", "supportedTriples": ["aarch64-unknown-linux-gnu", "aarch64-swift-linux-musl"] }
               ]
             },
             "Comment": {
               "type": "executable",
               "version": "$TAG",
               "variants": [
-                { "path": "x86_64-unknown-linux-gnu/Comment", "supportedTriples": ["x86_64-unknown-linux-gnu"] },
-                { "path": "aarch64-unknown-linux-gnu/Comment", "supportedTriples": ["aarch64-unknown-linux-gnu"] }
+                { "path": "x86_64-unknown-linux-gnu/Comment", "supportedTriples": ["x86_64-unknown-linux-gnu", "x86_64-swift-linux-musl"] },
+                { "path": "aarch64-unknown-linux-gnu/Comment", "supportedTriples": ["aarch64-unknown-linux-gnu", "aarch64-swift-linux-musl"] }
               ]
             }
           }

--- a/.github/workflows/ArtifactBundle.yaml
+++ b/.github/workflows/ArtifactBundle.yaml
@@ -55,6 +55,8 @@ jobs:
         mise_toml: |
           [tools]
           swift = "6.3.2"
+          [settings]
+          experimental = true
     - name: Install Static Linux SDK
       run: swift sdk install https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz --checksum 3fd798bef6f4408f1ea5a6f94ce4d4052830c4326ab85ebc04f983f01b3da407
     - name: Build static binaries

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "011f0c765fb46d9cac61bca19be0527e99c98c8b",
-        "version" : "1.5.1"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types",
       "state" : {
-        "revision" : "ae67c8178eb46944fd85e4dc6dd970e1f3ed6ccd",
-        "version" : "1.3.0"
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-runtime",
       "state" : {
-        "revision" : "8f33cc5dfe81169fb167da73584b9c72c3e8bc23",
-        "version" : "1.8.2"
+        "revision" : "3d3a8457661daf7fb260ceeb9f0e24e5204ba5fb",
+        "version" : "1.12.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-urlsession",
       "state" : {
-        "revision" : "279aa6b77be6aa842a4bf3c45fa79fa15edf3e07",
-        "version" : "1.2.0"
+        "revision" : "576a65b4ffb8c12ddad4950dc21eea2ef071bec2",
+        "version" : "1.3.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams",
       "state" : {
-        "revision" : "9281f8c99aff4f4a55dce22ae29b1181c935caa5",
-        "version" : "6.0.0"
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
       }
     }
   ],


### PR DESCRIPTION
## Why

The first ArtifactBundle run failed at link time: `--static-swift-stdlib`'s static FoundationNetworking references `curl_ws_*` symbols, but Ubuntu's libcurl is built without websocket support.

## What

- Switch to the official **Static Linux SDK (musl)** — fully static binaries, zero runtime dependency on the host's Swift or libcurl, portable across distros
- Pin the toolchain to 6.3.2 via mise (must exactly match the SDK version); both triples now cross-compile from x86_64 runners
- Enable mise `experimental` setting (required by the swift core tool)
- Bump `swift-openapi-urlsession` to **1.3.0**: earlier versions only handle Darwin/Android/Glibc in `Lock.swift` and fail to compile against musl; 1.3.0 added the Musl branch (other pins moved to latest in the same `swift package update`)

## Verification

Dispatched against this branch (run 27409406458): both `build-binaries` matrix jobs (x86_64 + aarch64 musl) **succeeded**; the upload job failed only because the test used a branch ref with no corresponding release — expected.

## Note

Backfilling a bundle onto 1.0.9 is not possible: that tag's committed `Package.resolved` pins musl-incompatible dependency versions. Bootstrap will instead create the next release manually and build its bundle directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)